### PR TITLE
Add Tailwind CSS v3 support for theme export

### DIFF
--- a/components/export-menu.tsx
+++ b/components/export-menu.tsx
@@ -1,18 +1,19 @@
 "use client";
 
-import { useState } from "react";
-import { useThemeStore } from "@/lib/store";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
-  DialogDescription,
 } from "@/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Button } from "@/components/ui/button";
-import { Copy, Download, Check } from "lucide-react";
+import { useThemeStore } from "@/lib/store";
+import { Check, Copy, Download } from "lucide-react";
+import { useState } from "react";
 import { toast } from "sonner";
+import { Separator } from "./ui/separator";
 
 export function ExportMenu() {
   const {
@@ -24,9 +25,12 @@ export function ExportMenu() {
   const [copied, setCopied] = useState(false);
   const [registryCopied, setRegistryCopied] = useState(false);
   const [selectedPackageManager, setSelectedPackageManager] = useState("pnpm");
+  const [selectedTailwindVersion, setSelectedTailwindVersion] = useState("v4");
 
   const handleCopy = () => {
-    navigator.clipboard.writeText(generateCSSVariables());
+    navigator.clipboard.writeText(
+      generateCSSVariables(selectedTailwindVersion === "v3")
+    );
     setCopied(true);
     toast("Copied to clipboard!");
     setTimeout(() => setCopied(false), 2000);
@@ -42,7 +46,7 @@ export function ExportMenu() {
   };
 
   const handleDownload = () => {
-    const code = generateCSSVariables();
+    const code = generateCSSVariables(selectedTailwindVersion === "v3");
     const blob = new Blob([code], { type: "text/css" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
@@ -74,6 +78,8 @@ export function ExportMenu() {
     selectedPackageManager,
     registryUrl
   );
+
+  const tailwindVersions = ["v4", "v3"];
 
   return (
     <Dialog open={exportMenuOpen} onOpenChange={setExportMenuOpen}>
@@ -131,9 +137,38 @@ export function ExportMenu() {
           <p className="mt-2 text-xs text-gray-600">
             Import your theme directly with the shadcn registry endpoint.
           </p>
+          <Separator className="bg-gray-200 my-4" />
+          <div className="flex flex-col gap-2">
+            <p className="font-medium mb-1">Tailwind CSS Version:</p>
+
+            <div className="flex flex-wrap gap-2 mt-1">
+              {tailwindVersions.map((version) => (
+                <Button
+                  key={version}
+                  size="sm"
+                  variant={
+                    selectedTailwindVersion === version ? "default" : "outline"
+                  }
+                  onClick={() => setSelectedTailwindVersion(version)}
+                  className={`h-7 px-2 text-xs ${
+                    selectedTailwindVersion === version
+                      ? "bg-gray-800 text-white hover:bg-gray-900"
+                      : "bg-white text-gray-600 border border-gray-300 hover:bg-gray-50"
+                  }`}
+                >
+                  {version}
+                </Button>
+              ))}
+            </div>
+
+            <p className="mt-2 text-xs text-gray-600">
+              Select your Tailwind CSS version. v3 uses hsl colors, v4 uses
+              oklch colors.
+            </p>
+          </div>
         </div>
 
-        <Tabs defaultValue="globals" className="mt-4">
+        <Tabs defaultValue="globals" className="">
           <TabsList className="grid w-full grid-cols-1 bg-gray-100 rounded-md">
             <TabsTrigger value="globals" className="text-gray-700 rounded">
               globals.css
@@ -143,7 +178,9 @@ export function ExportMenu() {
           <TabsContent value="globals">
             <div className="relative">
               <pre className="p-4 rounded-md bg-gray-50 border border-gray-200 overflow-auto max-h-[400px] text-sm text-gray-800 scrollbar-thin scrollbar-thumb-gray-300">
-                <code>{generateCSSVariables()}</code>
+                <code>
+                  {generateCSSVariables(selectedTailwindVersion === "v3")}
+                </code>
               </pre>
               <div className="absolute top-2 right-2 flex gap-2 mr-2">
                 <Button
@@ -174,7 +211,7 @@ export function ExportMenu() {
         <div className="mt-4 p-4 bg-gray-50 border border-gray-200 rounded-md text-gray-700 text-sm">
           <p className="font-medium mb-1">Requirements:</p>
           <ul className="list-disc list-inside space-y-1">
-            <li>Tailwind CSS v4 or later</li>
+            <li>Tailwind CSS {selectedTailwindVersion} or later</li>
             <li>shadcn/ui</li>
           </ul>
         </div>

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,13 +1,13 @@
-import { create } from "zustand";
-import { persist } from "zustand/middleware";
 import type {
+  ColorHarmony,
+  FontKey,
   ThemeColorKey,
   ThemeColors,
-  ThemeState,
-  FontKey,
-  ColorHarmony,
   ThemePreset,
+  ThemeState,
 } from "@/types/theme";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
 import { formatToOklch } from "./color-utils";
 import { getRegistryUrl } from "./theme-url";
 
@@ -729,7 +729,7 @@ export type ThemeStore = ThemeState & {
   setExportMenuOpen: (isOpen: boolean) => void;
   setShareMenuOpen: (isOpen: boolean) => void;
   getHexColor: (colorKey: ThemeColorKey) => string;
-  generateCSSVariables: () => string;
+  generateCSSVariables: (useV3?: boolean) => string;
   getShareableUrl: () => string;
   getRegistryUrl: () => string;
   applyThemeState: (themeState: Partial<ThemeState>) => void;
@@ -1403,10 +1403,96 @@ export const useThemeStore = create<ThemeStore>()(
         return getRegistryUrl(state);
       },
 
-      generateCSSVariables: () => {
+      generateCSSVariables: (useV3 = false) => {
         const state = get();
         const { colors, darkColors, borderRadius } = state;
 
+        // For Tailwind v3 format, use HSL values directly without conversion
+        if (useV3) {
+          return `@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: ${colors.background};
+    --foreground: ${colors.foreground};
+    --card: ${colors.card};
+    --card-foreground: ${colors.cardForeground};
+    --popover: ${colors.popover};
+    --popover-foreground: ${colors.popoverForeground};
+    --primary: ${colors.primary};
+    --primary-foreground: ${colors.primaryForeground};
+    --secondary: ${colors.secondary};
+    --secondary-foreground: ${colors.secondaryForeground};
+    --muted: ${colors.muted};
+    --muted-foreground: ${colors.mutedForeground};
+    --accent: ${colors.accent};
+    --accent-foreground: ${colors.accentForeground};
+    --destructive: ${colors.destructive};
+    --destructive-foreground: ${colors.primaryForeground};
+    --border: ${colors.border};
+    --input: ${colors.input};
+    --ring: ${colors.ring};
+    --radius: ${borderRadius}rem;
+    --chart-1: ${colors.chart1};
+    --chart-2: ${colors.chart2};
+    --chart-3: ${colors.chart3};
+    --chart-4: ${colors.chart4};
+    --chart-5: ${colors.chart5};
+    --sidebar-background: ${colors.sidebar};
+    --sidebar-foreground: ${colors.sidebarForeground};
+    --sidebar-primary: ${colors.sidebarPrimary};
+    --sidebar-primary-foreground: ${colors.sidebarPrimaryForeground};
+    --sidebar-accent: ${colors.sidebarAccent};
+    --sidebar-accent-foreground: ${colors.sidebarAccentForeground};
+    --sidebar-border: ${colors.sidebarBorder};
+    --sidebar-ring: ${colors.sidebarRing};
+  }
+
+  .dark {
+    --background: ${darkColors.background};
+    --foreground: ${darkColors.foreground};
+    --card: ${darkColors.card};
+    --card-foreground: ${darkColors.cardForeground};
+    --popover: ${darkColors.popover};
+    --popover-foreground: ${darkColors.popoverForeground};
+    --primary: ${darkColors.primary};
+    --primary-foreground: ${darkColors.primaryForeground};
+    --secondary: ${darkColors.secondary};
+    --secondary-foreground: ${darkColors.secondaryForeground};
+    --muted: ${darkColors.muted};
+    --muted-foreground: ${darkColors.mutedForeground};
+    --accent: ${darkColors.accent};
+    --accent-foreground: ${darkColors.accentForeground};
+    --destructive: ${darkColors.destructive};
+    --destructive-foreground: ${darkColors.primaryForeground};
+    --border: ${darkColors.border};
+    --input: ${darkColors.input};
+    --ring: ${darkColors.ring};
+    --sidebar-background: ${darkColors.sidebar};
+    --sidebar-foreground: ${darkColors.sidebarForeground};
+    --sidebar-primary: ${darkColors.sidebarPrimary};
+    --sidebar-primary-foreground: ${darkColors.sidebarPrimaryForeground};
+    --sidebar-accent: ${darkColors.sidebarAccent};
+    --sidebar-accent-foreground: ${darkColors.sidebarAccentForeground};
+    --sidebar-border: ${darkColors.sidebarBorder};
+    --sidebar-ring: ${darkColors.sidebarRing};
+  }
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+    font-feature-settings: "rlig" 1, "calt" 1;
+  }
+}`.trim();
+        }
+
+        // For Tailwind v4 format with OKLCH colors (existing format)
         return `@import "tailwindcss";
 @import "tw-animate-css";
 


### PR DESCRIPTION
## Description

This PR adds support for Tailwind CSS v3 colors in the theme export menu. Users can now switch between generating CSS variables for Tailwind v3 (HSL colors) and v4 (OKLCH colors).

## Changes

- Enhanced `ExportMenu` component with a version selector for Tailwind CSS (v3/v4)
- Modified `generateCSSVariables` function to support both v3 and v4 color formats
- Added conditional logic to use the appropriate color format based on user selection
- Improved UI with clearer version selection controls
- Updated requirements display to show the selected Tailwind version

## Why

This enhancement provides backward compatibility for projects still using Tailwind CSS v3, like NativeWind, which uses HSL color format instead of the OKLCH format used in v4. This makes the tool more useful for a wider range of projects and developers.

## Testing

- Tested theme export with both v3 and v4 selected
- Verified that the correct color formats are generated for each version
- Confirmed that the copied/downloaded CSS works correctly in both v3 and v4 projects


### Screenshot

https://github.com/user-attachments/assets/36bdf863-6d33-4895-a28b-916c36962d40


